### PR TITLE
Add segmented tabs to friends page for followers, following, and explore

### DIFF
--- a/BucketsApp/View/Social/FriendsView.swift
+++ b/BucketsApp/View/Social/FriendsView.swift
@@ -9,7 +9,16 @@ import SwiftUI
 
 struct FriendsView: View {
     @EnvironmentObject var viewModel: FriendsViewModel
-    
+    @State private var selectedTab: FriendTab = .following
+
+    enum FriendTab: String, CaseIterable, Identifiable {
+        case following = "Following"
+        case followers = "Followers"
+        case explore = "Explore"
+
+        var id: Self { self }
+    }
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -21,9 +30,17 @@ struct FriendsView: View {
                     let following = viewModel.filteredFollowing
                     let followers = viewModel.filteredFollowers
 
+                    Picker("", selection: $selectedTab) {
+                        ForEach(FriendTab.allCases) { tab in
+                            Text(tab.rawValue).tag(tab)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding([.horizontal, .top])
+
                     List {
-                        // --- Explore Section
-                        Section(header: Text("Explore")) {
+                        switch selectedTab {
+                        case .explore:
                             if explore.isEmpty {
                                 Text("No users to explore.")
                                     .foregroundColor(.secondary)
@@ -32,10 +49,7 @@ struct FriendsView: View {
                                     userRow(for: user)
                                 }
                             }
-                        }
-
-                        // --- Following Section
-                        Section(header: Text("Following")) {
+                        case .following:
                             if following.isEmpty {
                                 Text("You're not following anyone yet.")
                                     .foregroundColor(.secondary)
@@ -44,10 +58,7 @@ struct FriendsView: View {
                                     userRow(for: user)
                                 }
                             }
-                        }
-
-                        // --- Followers Section
-                        Section(header: Text("Followers")) {
+                        case .followers:
                             if followers.isEmpty {
                                 Text("You don't have any followers yet.")
                                     .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
- replace combined friends list with segmented tabs for Following, Followers, and Explore
- keep search and refresh while simplifying navigation

## Testing
- `xcodebuild -project BucketsApp.xcodeproj -list` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b64f37ec832a9a2726be644b6ee0