### PR TITLE
Ensure default profile avatar and sync updates

### DIFF
--- a/BucketsApp/View/List/ListView.swift
+++ b/BucketsApp/View/List/ListView.swift
@@ -386,7 +386,18 @@ struct ListView: View {
     // MARK: - Profile Image Helper
     @ViewBuilder
     private var profileImageView: some View {
-        if let urlString = userViewModel.user?.profileImageUrl,
+        if let data = userViewModel.profileImageData,
+           !data.isEmpty,
+           let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .stroke(Color.accentColor, lineWidth: 2)
+                )
+        } else if let urlString = userViewModel.user?.profileImageUrl,
            !urlString.isEmpty,
            let url = URL(string: urlString) {
             AsyncImage(url: url) { phase in

--- a/BucketsApp/ViewModel/UserViewModel.swift
+++ b/BucketsApp/ViewModel/UserViewModel.swift
@@ -234,6 +234,7 @@ class UserViewModel: ObservableObject {
             print("[UserViewModel] Profile image loaded.")
         } catch {
             print("[UserViewModel] Failed to load profile image:", error.localizedDescription)
+            profileImageData = nil
         }
     }
     
@@ -297,10 +298,16 @@ class UserViewModel: ObservableObject {
             self.user = try snapshot.data(as: UserModel.self)
             self.user?.documentId = userId
             self.isUserLoaded = true
+
+            // Reset any cached profile image when switching accounts or when
+            // the stored URL is empty so that brand new users see the default
+            // avatar until they upload their own image.
             if let url = self.user?.profileImageUrl, !url.isEmpty {
                 Task {
                     await self.loadProfileImage()
                 }
+            } else {
+                self.profileImageData = nil
             }
             print("[UserViewModel] loadCurrentUser: Refreshed user document.")
         } catch {


### PR DESCRIPTION
## Summary
- reset cached profile images when loading a user without a stored URL so new accounts display the default avatar
- clear cached data when loading from storage fails to avoid showing stale photos
- update the list toolbar avatar to prefer the in-memory profile image data so it refreshes immediately after uploads

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d97d4776d0832aa1c1c2ed26d9974a