### PR TITLE
Move profile avatar to trailing toolbar

### DIFF
--- a/BucketsApp/View/List/ListView.swift
+++ b/BucketsApp/View/List/ListView.swift
@@ -190,22 +190,22 @@ struct ListView: View {
                 }
                 // Restore top toolbar and toolbarBackground
                 .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button {
-                            showProfileView = true
-                        } label: {
-                            profileImageView
-                                .frame(width: 36, height: 36)
-                        }
-                    }
-
                     ToolbarItem(placement: .topBarTrailing) {
-                        if isAnyTextFieldActive {
-                            Button("Done") {
-                                UIApplication.shared.endEditing()
-                                focusedItemID = nil
+                        HStack(spacing: 12) {
+                            Button {
+                                showProfileView = true
+                            } label: {
+                                profileImageView
+                                    .frame(width: 36, height: 36)
                             }
-                            .bold()
+
+                            if isAnyTextFieldActive {
+                                Button("Done") {
+                                    UIApplication.shared.endEditing()
+                                    focusedItemID = nil
+                                }
+                                .bold()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- move the profile avatar button to the trailing side of the list toolbar
- group the avatar with the "Done" control so the avatar shifts left when editing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9857e22d0832a8cdfb8cfa5bc1cd9