### PR TITLE
Require username setup after Google sign-in

### DIFF
--- a/BucketsApp/BucketsApp.swift
+++ b/BucketsApp/BucketsApp.swift
@@ -95,6 +95,7 @@ struct BucketsApp: App {
                                 }
 
                                 await userViewModel.initializeUserSession(for: firebaseUser.uid, email: firebaseUser.email ?? "unknown")
+                                onboardingViewModel.refreshUsernameRequirement(using: userViewModel)
                                 let userId = firebaseUser.uid
                                 feedViewModel.startListeningToPosts(for: [userId])
                                 await friendsViewModel.loadFriendsData()

--- a/BucketsApp/View/OnBoarding/OnBoardingView.swift
+++ b/BucketsApp/View/OnBoarding/OnBoardingView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct OnboardingView: View {
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var userViewModel: UserViewModel
     @State private var showSignUp = false
     @State private var showLogIn = false
-    @State private var showUsernameSetup = false
     
     // Detect whether we’re in Light or Dark mode
     @Environment(\.colorScheme) private var colorScheme
@@ -84,11 +84,7 @@ struct OnboardingView: View {
                         
                         // MARK: - Google Sign-In Button
                         Button(action: {
-                            onboardingViewModel.signInWithGoogle(completion: { success in
-                                if success {
-                                    showUsernameSetup = true
-                                }
-                            })
+                            onboardingViewModel.signInWithGoogle(using: userViewModel, completion: { _ in })
                         }) {
                             HStack {
                                 Image("google_logo")
@@ -105,10 +101,6 @@ struct OnboardingView: View {
                             .foregroundColor(.primary)
                             .cornerRadius(10)
                             .shadow(radius: 5)
-                        }
-                        .sheet(isPresented: $showUsernameSetup) {
-                            UsernameSetupView()
-                                .environmentObject(onboardingViewModel)
                         }
                     }
                     .padding(.horizontal)

--- a/BucketsApp/View/OnBoarding/UsernameSetupView.swift
+++ b/BucketsApp/View/OnBoarding/UsernameSetupView.swift
@@ -9,11 +9,15 @@ import SwiftUI
 
 struct UsernameSetupView: View {
     @EnvironmentObject var userViewModel: UserViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var username: String = ""
+    @State private var username: String = "@"
     @State private var isUsernameValid: Bool = false
     @State private var isCheckingAvailability: Bool = false
+    @State private var isSubmitting: Bool = false
     @State private var errorMessage: String?
+    @State private var validationTask: Task<Void, Never>?
+    @State private var hasInteracted = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -21,13 +25,21 @@ struct UsernameSetupView: View {
                 .font(.largeTitle)
                 .bold()
 
+            Text("Pick a unique handle to represent you in Buckets. We'll use this on your profile and posts.")
+                .multilineTextAlignment(.center)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
             TextField("Enter a unique username", text: $username)
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .onChange(of: username) {
-                    Task {
-                        await validateUsername(username)
+                    hasInteracted = true
+                    validationTask?.cancel()
+                    let latest = username
+                    validationTask = Task {
+                        await validateUsername(latest)
                     }
                 }
 
@@ -37,52 +49,151 @@ struct UsernameSetupView: View {
                     .font(.caption)
             }
 
+            if isCheckingAvailability {
+                ProgressView("Checking availability…")
+                    .progressViewStyle(.circular)
+            }
+
             Button(action: {
                 Task {
-                    let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
-                    await userViewModel.updateUserName(to: trimmed)
-                    if userViewModel.user?.username == trimmed {
-                        dismiss()
-                    }
+                    await submitUsername()
                 }
             }) {
-                Text("Continue")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(isUsernameValid ? Color.accentColor : Color.gray.opacity(0.4))
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
+                if isSubmitting {
+                    ProgressView()
+                        .tint(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                } else {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                }
             }
-            .disabled(!isUsernameValid)
+            .background(isUsernameValid ? Color.accentColor : Color.gray.opacity(0.4))
+            .foregroundColor(.white)
+            .cornerRadius(10)
+            .disabled(!isUsernameValid || isSubmitting)
             .padding(.top)
 
             Spacer()
         }
         .padding()
+        .onAppear {
+            hasInteracted = false
+            if let existing = userViewModel.user?.username,
+               !existing.isEmpty,
+               existing != "@unknown" {
+                username = existing
+                isUsernameValid = true
+            }
+        }
+        .onDisappear {
+            validationTask?.cancel()
+        }
     }
 
     private func validateUsername(_ input: String) async {
-        isCheckingAvailability = true
-        errorMessage = nil
+        await MainActor.run {
+            isCheckingAvailability = true
+            errorMessage = nil
+        }
 
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        await MainActor.run {
+            if trimmed.isEmpty {
+                isUsernameValid = false
+            }
+        }
+
         guard !trimmed.isEmpty else {
-            isUsernameValid = false
+            await MainActor.run {
+                isCheckingAvailability = false
+            }
+            return
+        }
+
+        guard trimmed.hasPrefix("@") else {
+            await MainActor.run {
+                isUsernameValid = false
+                errorMessage = "Username must start with @"
+                isCheckingAvailability = false
+            }
+            return
+        }
+
+        guard trimmed.count >= 3 else {
+            await MainActor.run {
+                isUsernameValid = false
+                errorMessage = "Usernames must be at least 3 characters."
+                isCheckingAvailability = false
+            }
+            return
+        }
+
+        if trimmed == userViewModel.user?.username {
+            await MainActor.run {
+                isUsernameValid = true
+                isCheckingAvailability = false
+            }
+            return
+        }
+
+        if Task.isCancelled {
+            await MainActor.run {
+                isCheckingAvailability = false
+            }
             return
         }
 
         let available = await userViewModel.checkUsernameAvailability(trimmed)
-        if available {
-            isUsernameValid = true
-        } else {
-            isUsernameValid = false
-            errorMessage = "That username is already taken."
+
+        if Task.isCancelled {
+            await MainActor.run {
+                isCheckingAvailability = false
+            }
+            return
         }
 
-        isCheckingAvailability = false
+        await MainActor.run {
+            if available {
+                isUsernameValid = true
+            } else {
+                isUsernameValid = false
+                errorMessage = "That username is already taken."
+            }
+            isCheckingAvailability = false
+        }
+    }
+
+    private func submitUsername() async {
+        let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isUsernameValid else { return }
+
+        await MainActor.run {
+            isSubmitting = true
+            errorMessage = nil
+        }
+
+        await userViewModel.updateUserName(to: trimmed)
+        onboardingViewModel.refreshUsernameRequirement(using: userViewModel)
+
+        await MainActor.run {
+            isSubmitting = false
+            if onboardingViewModel.shouldPromptUsername {
+                let fallback = userViewModel.errorMessage ?? "We couldn't save that username. Please try another one."
+                errorMessage = fallback
+                isUsernameValid = false
+            } else {
+                onboardingViewModel.username = trimmed
+                dismiss()
+            }
+        }
     }
 }
 
 #Preview {
     UsernameSetupView()
+        .environmentObject(UserViewModel())
+        .environmentObject(OnboardingViewModel())
 }


### PR DESCRIPTION
## Summary
- initialize the user session after Google authentication and track when a username is required before entering the app
- trigger Google sign-in from onboarding with access to the user view model so username gating can be evaluated
- refresh the username setup experience with validation, guidance, and loading states before allowing the user to continue

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e45d7e17a0832aae6787bc6551a338