### PR TITLE
Improve like interaction in feed

### DIFF
--- a/BucketsApp/View/Social/FeedView.swift
+++ b/BucketsApp/View/Social/FeedView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct FeedView: View {
     @EnvironmentObject var feedViewModel: FeedViewModel
-    @EnvironmentObject var postViewModel: PostViewModel
     @EnvironmentObject var userViewModel: UserViewModel
     @EnvironmentObject var bucketListViewModel: ListViewModel
     @EnvironmentObject var syncCoordinator: SyncCoordinator
@@ -37,9 +36,7 @@ struct FeedView: View {
                                     post: post,
                                     item: matchedItem,
                                     onLike: {
-                                        Task {
-                                            await postViewModel.toggleLike(for: post.id ?? "", by: userViewModel.user?.id ?? "")
-                                        }
+                                        await feedViewModel.toggleLike(post: post)
                                     }
                                 )
                                 .task {


### PR DESCRIPTION
## Summary
- restyle the feed like control with a larger tappable capsule and accessibility text
- route like actions through the feed view model for consistent optimistic updates
- optimistically update like counts with animation and revert on failures

## Testing
- Not run (requires iOS tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e45efcc08c832a8a3f58296899aa8c